### PR TITLE
Set up continuous deployment of a production docker container

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,48 @@
+name: Create and publish Docker image
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Checkout magpie-backend
+        uses: actions/checkout@v2
+        with:
+          repository: magpie-ea/magpie-backend
+          path: app
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./docker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,50 @@
+# This Dockerfile creates a release image
+# while the Dockerfile in the root dir of this
+# repo creates a development image
+FROM elixir:1.13
+
+RUN mix local.hex --force \
+ && mix archive.install hex phx_new \
+ && apt-get update \
+ && curl -sL https://deb.nodesource.com/setup_14.x | bash \
+ && apt-get install -y apt-utils \
+ && apt-get install -y nodejs \
+ && apt-get install -y build-essential \
+ && apt-get install -y inotify-tools \
+ && mix local.rebar --force
+
+# Similar to cd
+WORKDIR /app
+
+COPY app/assets assets
+
+RUN cd assets \
+    && npm install
+
+RUN mix assets.deploy
+
+COPY app/priv priv
+
+ENV MIX_ENV="prod"
+
+COPY app/mix.exs app/mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+
+# copy compile-time config files before we compile dependencies
+# to ensure any relevant config change will trigger the dependencies
+# to be re-compiled.
+COPY app/config/config.exs app/config/${MIX_ENV}.exs config/
+RUN mix deps.compile
+
+COPY app/lib lib
+
+COPY app/config/releases.exs config/
+
+COPY app/rel rel
+
+ADD entrypoint.sh /
+
+EXPOSE 4000
+
+CMD ["/bin/bash", "/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#! /bin/env bash
+mix phx.digest
+mix release --force --overwrite
+./_build/prod/rel/magpie/bin/magpie eval 'Magpie.ReleaseTasks.db_migrate()' || true
+./_build/prod/rel/magpie/bin/magpie eval 'Magpie.ReleaseTasks.db_migrate()'
+./_build/prod/rel/magpie/bin/magpie start


### PR DESCRIPTION
As the backend continues to evolve, it would be cool to have a CD pipeline for the prod container that is used in the end-to-end tests.

This PR adds a GitHub Action that automatically builds and pushes the prod container whenever commits are pushed to master.

NB: I'm not sure the Dockerfile is correct as magpie-docker has been failing for a while with your newest changes (likely the esbuild change)

@x-ji Feel free to fix as you see fit